### PR TITLE
fix handling of does and DOES

### DIFF
--- a/lib/Safe/Isa.pm
+++ b/lib/Safe/Isa.pm
@@ -15,19 +15,31 @@ our $_call_if_object = sub {
   # we gratuitously break modules like Scalar::Defer, which would be
   # un-perlish.
   return unless Scalar::Util::blessed($obj);
-  return $obj->isa(@_) if lc($method) eq 'does' and not $obj->can($method);
   return $obj->$method(@_);
 };
 
-our ($_isa, $_can, $_does, $_DOES) = map {
+our ($_isa, $_can) = map {
   my $method = $_;
   sub { my $obj = shift; $obj->$_call_if_object($method => @_) }
-} qw(isa can does DOES);
+} qw(isa can);
 
 our $_call_if_can = sub {
   my ($obj, $method) = (shift, shift);
   return unless $obj->$_call_if_object(can => $method);
   return $obj->$method(@_);
+};
+
+our $_does = sub {
+  my $obj = shift;
+  $obj->$_call_if_can(does => @_);
+};
+
+our $_DOES = sub {
+  my $obj = shift;
+  return unless Scalar::Util::blessed($obj);
+  return $obj->DOES(@_)
+    if $obj->can('DOES');
+  return $obj->isa(@_);
 };
 
 1;

--- a/lib/Safe/Isa.pm
+++ b/lib/Safe/Isa.pm
@@ -160,14 +160,17 @@ returns nothing.
   $maybe_an_object->$_does('Foo');
 
 If called on an object, calls C<does> on it and returns the result, otherwise
-returns nothing.
+returns nothing. If the C<does> method does not exist, returns nothing rather
+than failing.
 
 =head2 $_DOES
 
   $maybe_an_object->$_DOES('Foo');
 
 If called on an object, calls C<DOES> on it and returns the result, otherwise
-returns nothing.
+returns nothing. On perl versions prior to 5.10.0, the built in core C<DOES>
+method doesn't exist. If the method doesn't exist, this will fall back to
+calling C<isa> just like the core C<DOES> method.
 
 =head2 $_call_if_object
 

--- a/t/safe_does.t
+++ b/t/safe_does.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 14;
+use Test::More tests => 20;
 
 { package Foo; sub new { bless({}, $_[0]) } }
 { package Bar; our @ISA = qw(Foo); sub bar { 1 } sub does { $_[0]->isa($_[1]) } }
@@ -36,9 +36,16 @@ ok($bar->$_DOES('Foo'), 'bar $_DOES Foo');
 ok(eval { $blam->$_DOES('Foo'); 1 }, 'no boom today');
 ok(eval { $undef->$_DOES('Foo'); 1 }, 'nor tomorrow either');
 
+# does should not fall back to isa
+ok(!$foo->$_does('Foo'), 'foo !$_does Foo');
+ok($bar->$_does('Foo'), 'bar $_does Foo');
+ok(eval { $blam->$_does('Foo'); 1 }, 'no boom today');
+ok(eval { $undef->$_does('Foo'); 1 }, 'nor tomorrow either');
 
 ok($foo->$_call_if_object(DOES => 'Foo'), 'foo $_call_if_object(DOES => Foo)');
 ok($bar->$_call_if_object(DOES => 'Foo'), 'bar $_call_if_object(DOES => Foo)');
 ok(eval { $blam->$_call_if_object(DOES => 'Foo'); 1 }, 'no boom today');
 ok(eval { $undef->$_call_if_object(DOES => 'Foo'); 1 }, 'nor tomorrow either');
 
+ok(!eval { $foo->$_call_if_object(does => 'Foo'); 1 }, 'no special DOES handling built into _call_if_object');
+ok(!eval { $foo->$_call_if_object(Does => 'Foo'); 1 }, 'and no handling for wrong case');


### PR DESCRIPTION
does should only try to use the object's does, falling back to undef.
DOES should fall back to isa if DOES doesn't exist.
Other things like doES shouldn't have any special handling.